### PR TITLE
Remove reference to the request helper

### DIFF
--- a/spootify/README.md
+++ b/spootify/README.md
@@ -27,7 +27,6 @@
 
 # What's Already Been Done 🏁
 - UI/UX for all elements, including previews (mobile responsive)
-- A Spotify request helper (`makeRequest.js`)
 
 # Screenshots 🌄
 


### PR DESCRIPTION
The `makeRequest.js` request helper no longer exists, so I'm removing the information about it.

Signed-off-by: Clement Ng <clementdng@gmail.com>